### PR TITLE
Add ts support for providing array of globs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ WebpackSweetEntry(path, ext, parentdir);
 
 | arg | type | Description | Example |
 | ---- | ---- | ----------- | ------- |
-| path | `string` | File path | `path.resolve(sourcePath, 'assets/js/**/*.js*')` |
+| path | `string` \| `array` | File path glob(s) | `path.resolve(sourcePath, 'assets/js/**/*.js*')` or `[path.resolve(sourcePath, 'assets/js/**/*.js*'), '!**/a.js']` |
 | ext | `string` \| `array` | File extension | `js` or `['ts', 'js']`
 | parentdir | `string` | Parent Dirctory Name for files | `js` |
 

--- a/src/__tests__/Multiple-glob.test.ts
+++ b/src/__tests__/Multiple-glob.test.ts
@@ -1,0 +1,16 @@
+import * as path from 'path';
+import { WebpackSweetEntry } from '../index';
+
+const tsPath = path.join(__dirname, 'files/single');
+const abPath = __dirname.replace('/webpack-sweet-entry/src/__tests__', '');
+const wse = WebpackSweetEntry([path.resolve(tsPath, '**/*.js*'), '!**/a.js'], 'js', 'single');
+const obj = Object.assign({}, ...Object.keys(wse).map(k => ({ [k]: wse[k].replace(abPath, '') })));
+
+describe('Test', () => {
+  it('toEqual()', () => {
+    expect(obj).toEqual({
+      b: '/webpack-sweet-entry/src/__tests__/files/single/b.js',
+      c: '/webpack-sweet-entry/src/__tests__/files/single/c.js',
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import fg from 'fast-glob';
+import { Pattern } from 'fast-glob/out/types';
 
 interface EntryPoints {
   [key: string]: string;
@@ -22,7 +23,11 @@ const createRegex = (ext: string[]) => {
   return new RegExp(`${d.join('|')}`, 'gi');
 };
 
-export const WebpackSweetEntry = (paths: string, ext: string | string[] = 'js', parentdir = 'js'): EntryPoints => {
+export const WebpackSweetEntry = (
+  paths: Pattern | Pattern[],
+  ext: string | string[] = 'js',
+  parentdir = 'js',
+): EntryPoints => {
   const g = fg.sync(paths);
   const r: EntryPoints = {};
   const rp = Array.isArray(ext) ? createRegex(ext) : `.${ext}`;


### PR DESCRIPTION
`fg.sync()` can accept an array of globs, to allow for things such as excluding a file or directory from the result. This PR corrects the TS typings to allow for an arrays of globs in the `paths` parameter.